### PR TITLE
feat: Use Docker volumes for basecfg and usercfg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,15 @@ COPY --from=builder /usr/src/app/node_modules ./node_modules
 # Copy the rest of the application code
 COPY . .
 
+# Copy basecfg to a default location
+COPY basecfg/ /usr/src/app/basecfg_default/
+
 # Expose the port the app runs on
 # This should match the HTTP_PORT in your .env file or the default in index.js
 EXPOSE 8080
 
-# Define the command to run the application
+# Define the entrypoint and command to run the application
+COPY entrypoint.sh /usr/src/app/entrypoint.sh
+RUN chmod +x /usr/src/app/entrypoint.sh
+ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
 CMD ["node", "index.js"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,4 +7,5 @@ services:
       - "8080:8080"
     volumes:
       - ./usercfg:/usr/src/app/usercfg
+      - ./basecfg:/usr/src/app/basecfg
     restart: unless-stopped

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Create usercfg directory if it doesn't exist
+if [ ! -d "/usr/src/app/usercfg" ]; then
+    mkdir -p /usr/src/app/usercfg
+    echo "Created usercfg directory."
+fi
+
+# Check if basecfg is empty, and if so, copy the default config
+if [ -z "$(ls -A /usr/src/app/basecfg)" ]; then
+    echo "basecfg is empty, copying default configuration..."
+    cp -r /usr/src/app/basecfg_default/* /usr/src/app/basecfg/
+fi
+
+# Execute the main command
+exec "$@"


### PR DESCRIPTION
This change modifies the docker-compose.yaml file to use Docker volumes for `basecfg` and `usercfg`. This allows you to easily modify the configuration files without having to rebuild the Docker image.

An entrypoint script has been added to initialize the volumes with the default configuration if they are empty.

The `ENTRYPOINT` and `CMD` have been moved to the `Dockerfile` to make the image more portable.